### PR TITLE
Add link to code on crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 RedOxide is a high-performance, modular, and extensible Red Teaming tool written in Rust. 
 It is designed to evaluate the safety and robustness of Large Language Models (LLMs) by simulating various adversarial attacks.
 
+`redoxide` is available from [`crates.io`](https://crates.io/crates/redoxide).
+
 
 ## Contents
 


### PR DESCRIPTION
* Adds information about redoxide availability on crates.io.